### PR TITLE
Add API endpoint and download option for structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A modern web application for exploring and visualizing protein structures from t
 - **📊 Detailed Protein Information**: View organism, gene names, confidence scores, and more
 - **📱 Responsive Design**: Works seamlessly on desktop and mobile devices
 - **⚡ Real-time Data**: Fetches latest structures directly from AlphaFold database
+- **💾 Easy Downloads**: Save predicted structures in PDB format with a single click
 - **🚀 Easy Deployment**: Ready for deployment on Render, Railway, Heroku, or Vercel
 
 ## 🚀 Quick Start
@@ -97,6 +98,9 @@ alphafold-3d-viewer/
 |--------|----------|-------------|
 | GET    | `/`      | Main application page |
 | POST   | `/search`| Search for protein structures |
+| GET    | `/api/structure/<UniProt_ID>` | Fetch structure metadata by UniProt ID |
+
+All API endpoints support cross-origin requests for easy integration.
 
 ### Search API Example
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, jsonify
+from flask_cors import CORS
 import requests
 import re
 import logging
@@ -10,6 +11,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+CORS(app)
 
 # API endpoints
 ALPHAFOLD_API = "https://alphafold.ebi.ac.uk/api/prediction/{}"
@@ -57,6 +59,19 @@ def search():
     except Exception as e:
         logger.error(f"Search error: {str(e)}")
         return jsonify({"error": "Internal server error"}), 500
+
+
+@app.route('/api/structure/<uniprot_id>', methods=['GET'])
+def get_structure(uniprot_id):
+    """API endpoint to fetch structure details by UniProt ID"""
+    if not is_uniprot_id(uniprot_id):
+        return jsonify({"error": "Invalid UniProt ID"}), 400
+
+    result = fetch_by_uniprot_id(uniprot_id)
+    if result:
+        return jsonify(result)
+
+    return jsonify({"error": "Structure not found"}), 404
 
 def is_uniprot_id(query):
     """Check if query matches UniProt ID pattern"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.3
 requests==2.31.0
 gunicorn==21.2.0
 Werkzeug==2.3.7
+Flask-Cors==4.0.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -321,6 +321,7 @@
             <div class="controls">
                 <button class="control-btn" onclick="resetView()">🔄 Reset View</button>
                 <button class="control-btn" onclick="toggleSpin()">🔄 Auto Rotate</button>
+                <button class="control-btn" onclick="downloadStructure()">💾 Download PDB</button>
                 <button class="control-btn" onclick="toggleFullscreen()">⛶ Fullscreen</button>
             </div>
         </div>
@@ -333,6 +334,7 @@
     <script>
         let viewer;
         let isSpinning = false;
+        let currentModelUrl = '';
 
         function setQuery(text) {
             document.getElementById('query').value = text;
@@ -414,9 +416,10 @@
             try {
                 const container = document.getElementById('viewerContainer');
                 const viewerTitle = document.getElementById('viewerTitle');
-                
+
                 container.style.display = 'block';
                 viewerTitle.textContent = `3D Structure: ${title}`;
+                currentModelUrl = url;
 
                 if (!viewer) {
                     viewer = await molstar.Viewer.create('viewer', {
@@ -443,6 +446,12 @@
             } catch (error) {
                 console.error('Structure loading error:', error);
                 showStatus('❌ Failed to load 3D structure', 'error');
+            }
+        }
+
+        function downloadStructure() {
+            if (currentModelUrl) {
+                window.open(currentModelUrl, '_blank');
             }
         }
 


### PR DESCRIPTION
## Summary
- add CORS support and new `/api/structure/<id>` endpoint to fetch structure metadata
- enable one-click PDB downloads and track current model in viewer
- document new API and feature and pin Flask-Cors dependency

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask_cors')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a34889cdd08328a93b09fb112fd9b1