### PR TITLE
fix: validate full UniProt IDs in search

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,7 +75,7 @@ def get_structure(uniprot_id):
 
 def is_uniprot_id(query):
     """Check if query matches UniProt ID pattern"""
-    pattern = r'^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$'
+    pattern = r'^([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})$'
     return bool(re.match(pattern, query.upper()))
 
 def is_protein_sequence(query):

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,15 @@
+import pytest
+
+from app import is_uniprot_id
+
+
+def test_valid_uniprot_id():
+    assert is_uniprot_id("P05067")
+
+
+def test_invalid_uniprot_id_with_extra_text():
+    assert not is_uniprot_id("P05067 extra")
+
+
+def test_invalid_short_code():
+    assert not is_uniprot_id("P53")


### PR DESCRIPTION
## Summary
- ensure UniProt ID regex matches entire query
- add tests covering valid and invalid IDs

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a34cdcdec88328969a4d37e615130f