### PR TITLE
Fix viewer clearing and search robustness

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,88 +1,141 @@
+"""Flask backend for the AlphaFold 3D viewer.
+
+This version hardens the search endpoint and makes the proxy more robust.
+It gracefully handles upstream network failures, verifies query types and
+ensures endpoints work when the app is hosted under a sub-path.
+"""
+
+import logging
 import os
 import re
-import json
 import urllib.parse
 from functools import lru_cache
 from typing import Optional
 
 import requests
-from flask import Flask, request, jsonify, render_template, Response, abort
+from flask import Flask, Response, abort, jsonify, render_template, request
 from flask_cors import CORS
 
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 APP_PORT = int(os.environ.get("PORT", "5000"))
-ALLOWED_PROXY_HOSTS = {"alphafold.ebi.ac.uk"}  # keep this tight
+ALLOWED_PROXY_HOSTS = {"alphafold.ebi.ac.uk"}
 
 app = Flask(__name__)
 CORS(app)
 
+
+# UniProt accession format. See https://www.uniprot.org/help/accession_numbers
 UNIPROT_RE = re.compile(
     r"^([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})$",
     re.IGNORECASE,
 )
 
+# Letters allowed for simple amino-acid sequence detection.
+VALID_AA_LETTERS = set("ACDEFGHIKLMNPQRSTVWY")
+
 
 def is_uniprot_id(q: str) -> bool:
+    """Return True if *q* matches the UniProt accession pattern."""
+
     return bool(UNIPROT_RE.match(q.strip()))
 
 
+def is_amino_acid_sequence(q: str) -> bool:
+    """Return True if *q* looks like a primary amino-acid sequence.
+
+    The heuristic requires at least 10 canonical residues. Ambiguous
+    letters like B/Z/X are intentionally disallowed.
+    """
+
+    s = q.strip().upper()
+    return len(s) >= 10 and all(c in VALID_AA_LETTERS for c in s)
+
+
 def build_afdb_pdb_url(accession: str) -> str:
-    # AlphaFold DB file naming (version 4 models)
-    # Example: https://alphafold.ebi.ac.uk/files/AF-P05067-F1-model_v4.pdb
+    """Construct the AlphaFold DB PDB URL for *accession*.
+
+    AlphaFold DB version 4 models follow the pattern
+    ``https://alphafold.ebi.ac.uk/files/AF-<ACC>-F1-model_v4.pdb``.
+    """
+
     acc = accession.strip().upper()
     return f"https://alphafold.ebi.ac.uk/files/AF-{acc}-F1-model_v4.pdb"
 
 
 @lru_cache(maxsize=256)
 def uniprot_lookup_by_name(name: str) -> Optional[str]:
+    """Resolve a protein *name* to a UniProt accession using UniProt's REST API.
+
+    Returns ``None`` on failure.
     """
-    Resolve a protein 'name' to a UniProt accession using UniProt's REST API.
-    We request 1 best hit. Fallback: None.
-    """
+
+    params = {
+        "query": name,
+        "format": "tsv",
+        "fields": "accession,protein_name,organism_name",
+        "size": 1,
+    }
     try:
-        # fields kept small to minimize payload;  size=1 for the top hit
-        params = {
-            "query": name,
-            "format": "tsv",
-            "fields": "accession,protein_name,organism_name",
-            "size": 1,
-        }
         r = requests.get(
             "https://rest.uniprot.org/uniprotkb/search",
             params=params,
             timeout=10,
         )
         r.raise_for_status()
-        lines = r.text.strip().splitlines()
-        if len(lines) < 2:
-            return None
-        header = lines[0].split("\t")
-        acc_idx = header.index("Entry")
-        first = lines[1].split("\t")
-        return first[acc_idx]
-    except Exception:
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.warning("UniProt lookup failed for '%s': %s", name, exc)
         return None
+
+    lines = r.text.strip().splitlines()
+    if len(lines) < 2:
+        return None
+    header = lines[0].split("\t")
+    try:
+        acc_idx = header.index("Entry")
+    except ValueError:
+        logger.warning("UniProt response missing 'Entry' column: %s", header)
+        return None
+    first = lines[1].split("\t")
+    return first[acc_idx]
 
 
 @app.get("/")
-def index():
+def index() -> str:
+    """Render the main page."""
+
     return render_template("index.html")
 
 
 @app.get("/api/health")
-def health():
+def health() -> Response:
+    """Simple health check endpoint."""
+
     return jsonify({"status": "ok"})
 
 
 @app.post("/search")
-def search():
+def search() -> Response:
+    """Resolve a UniProt accession and return the AlphaFold DB URL.
+
+    Request body: ``{"query": "<UniProt ID or protein name>"}``
+
+    If the query looks like an amino-acid sequence we return a 400 error with
+    an explanatory message, since sequence search is not supported yet.
     """
-    Input JSON: {"query": "..."} where query is UniProt ID (e.g. P05067) or a protein name (e.g. insulin).
-    Output JSON: {"accession": "...", "pdb_url": "..."} or 400 if cannot resolve.
-    """
+
     data = request.get_json(silent=True) or {}
     query = (data.get("query") or "").strip()
     if not query:
         return jsonify({"error": "Missing 'query'"}), 400
+
+    if is_amino_acid_sequence(query):
+        return (
+            jsonify({"error": "Searching by amino acid sequence is not yet supported."}),
+            400,
+        )
 
     if is_uniprot_id(query):
         acc = query.upper()
@@ -93,29 +146,31 @@ def search():
 
     pdb_url = build_afdb_pdb_url(acc)
 
-    # Optional: quick HEAD to verify existence (small extra cost but nicer UX)
+    # Verify the file exists with a HEAD request, but fail softly if network
+    # access is blocked. In that case we still return the URL so the client can
+    # attempt to fetch it via the proxy.
     try:
         head = requests.head(pdb_url, timeout=10)
         if head.status_code >= 400:
             return jsonify({"error": f"AlphaFold file not found for {acc}"}), 404
-    except Exception as e:
-        return jsonify({"error": f"Upstream check failed: {e}"}), 502
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.info("Skipping HEAD check for %s due to %s", pdb_url, exc)
 
     return jsonify({"accession": acc, "pdb_url": pdb_url})
 
 
 @app.get("/proxy")
-def proxy():
+def proxy() -> Response:
+    """Stream an AlphaFold PDB file to the client to avoid CORS issues.
+
+    Usage: ``/proxy?url=https://alphafold.ebi.ac.uk/files/AF-P05067-F1-model_v4.pdb``
+    Only hosts listed in :data:`ALLOWED_PROXY_HOSTS` are permitted.
     """
-    Stream a remote AlphaFold file to the browser to avoid CORS/mixed-content issues.
-    Usage: /proxy?url=https://alphafold.ebi.ac.uk/files/AF-P05067-F1-model_v4.pdb
-    Only whitelisted hosts are allowed.
-    """
+
     raw_url = request.args.get("url", "")
     if not raw_url:
         return abort(400, "Missing url")
 
-    # sanitize and restrict host
     try:
         parsed = urllib.parse.urlparse(raw_url)
     except Exception:
@@ -128,16 +183,15 @@ def proxy():
 
     try:
         upstream = requests.get(raw_url, stream=True, timeout=30)
-    except Exception as e:
-        return abort(502, f"Upstream error: {e}")
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.warning("Upstream fetch failed for %s: %s", raw_url, exc)
+        return abort(502, f"Upstream error: {exc}")
 
     if upstream.status_code >= 400:
         return abort(upstream.status_code)
 
-    # pass through content-type; default text/plain to be safe
     content_type = upstream.headers.get("Content-Type", "text/plain")
 
-    # stream chunks
     def gen():
         for chunk in upstream.iter_content(chunk_size=65536):
             if chunk:
@@ -146,6 +200,6 @@ def proxy():
     return Response(gen(), status=200, content_type=content_type)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     app.run(host="0.0.0.0", port=APP_PORT)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>AlphaFold 3D Protein Viewer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Mol* (no module build is easiest to use) -->
-  <script src="https://cdn.jsdelivr.net/npm/molstar@latest/build/viewer/molstar.js"></script>
+  <title>AlphaFold 3D Protein Viewer</title>
   <style>
     :root { color-scheme: light dark; }
     body { margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
@@ -18,7 +16,7 @@
     #viewer { width: 100%; height: 560px; border-radius: 12px; overflow: hidden; border: 1px solid #ccc; margin-top: 16px; }
     .muted { color: #666; }
     .examples a { margin-right: 10px; cursor: pointer; text-decoration: underline; }
-    .pill { display:inline-block; padding:4px 8px; border:1px solid #8884; border-radius:999px; font-size:12px; margin-right:8px;}
+    .pill { display:inline-block; padding:4px 8px; border:1px solid #8884; border-radius:999px; font-size:12px; margin-right:8px; }
   </style>
 </head>
 <body>
@@ -27,31 +25,29 @@
     <span class="pill">Mol*</span>
     <span class="pill">Flask</span>
   </header>
-
-  <main class="wrap">
-    <section>
-      <h2>Explore protein structures</h2>
-      <p class="muted">Search by <strong>UniProt ID</strong> (e.g. <code>P05067</code>) or protein name (e.g. “insulin”).</p>
-      <div class="row">
-        <input id="q" type="text" placeholder="e.g. P05067 or insulin" />
-        <button id="go">Search</button>
-        <button id="reset" title="Clear viewer">Reset</button>
-      </div>
-      <p class="examples muted">Try:
-        <a data-example="P05067">P05067</a>
-        <a data-example="TP53">TP53</a>
-        <a data-example="insulin">insulin</a>
-        <a data-example="hemoglobin">hemoglobin</a>
-        <a data-example="P38398">P38398</a>
-      </p>
-      <div id="status" class="muted"></div>
-      <div id="viewer"></div>
-      <p class="muted" style="margin-top:8px">Powered by <a href="https://alphafold.ebi.ac.uk" target="_blank" rel="noreferrer">AlphaFold DB</a> and <a href="https://molstar.org" target="_blank" rel="noreferrer">Mol*</a>.</p>
-    </section>
-  </main>
-
+  <div class="wrap">
+    <h2>Explore protein structures</h2>
+    <p>Search by UniProt ID (e.g. <code>P05067</code>) or protein name (e.g. “insulin”).</p>
+    <div class="row">
+      <input id="q" type="text" placeholder="Enter protein name or UniProt ID…" />
+      <button id="go">Search</button>
+      <button id="reset">Reset</button>
+    </div>
+    <p class="examples">Try:
+      <a data-example="P05067">P05067</a>
+      <a data-example="TP53">TP53</a>
+      <a data-example="insulin">insulin</a>
+      <a data-example="hemoglobin">hemoglobin</a>
+      <a data-example="P38398">P38398</a>
+    </p>
+    <div id="status" class="muted"></div>
+    <div id="viewer"></div>
+    <p class="muted">Powered by AlphaFold DB and Mol*.</p>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/molstar@3/build/viewer/molstar.js"></script>
   <script>
-    // Viewer boot
+    // Boot the Mol* viewer lazily. This avoids creating the viewer until
+    // needed and prevents multiple instances from being created.
     let viewer = null;
     function makeViewer() {
       if (viewer) return viewer;
@@ -65,13 +61,19 @@
       return viewer;
     }
 
+    // Load a PDB from the proxied URL and update the status text.
     async function loadAccession(acc, pdbUrl) {
       const v = makeViewer();
       document.getElementById('status').textContent = `Loading ${acc}…`;
       try {
-        await v.clear();
-        // load via our proxy to avoid CORS
-        const proxied = `/proxy?url=${encodeURIComponent(pdbUrl)}`;
+        if (v.plugin && typeof v.plugin.clear === 'function') {
+          await v.plugin.clear();
+        } else if (typeof v.clear === 'function') {
+          await v.clear();
+        }
+        // Build the proxied URL using Flask's url_for to respect prefixes.
+        const proxyBase = {{ url_for('proxy', _external=false) | tojson }};
+        const proxied = `${proxyBase}?url=${encodeURIComponent(pdbUrl)}`;
         await v.loadStructureFromUrl(proxied, 'pdb');
         document.getElementById('status').textContent = `Loaded ${acc}`;
       } catch (e) {
@@ -79,14 +81,22 @@
       }
     }
 
+    // Perform the search by calling the Flask backend.
     async function doSearch(query) {
       document.getElementById('status').textContent = 'Resolving…';
-      const res = await fetch('/search', {
+      const searchUrl = {{ url_for('search', _external=false) | tojson }};
+      const res = await fetch(searchUrl, {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ query })
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query }),
       });
-      const data = await res.json();
+      let data;
+      try {
+        data = await res.json();
+      } catch (err) {
+        document.getElementById('status').textContent = 'Search failed: invalid response';
+        return;
+      }
       if (!res.ok) {
         document.getElementById('status').textContent = data.error || 'Search failed';
         return;
@@ -101,7 +111,11 @@
     });
     document.getElementById('reset').addEventListener('click', async () => {
       if (!viewer) return;
-      await viewer.clear();
+      if (viewer.plugin && typeof viewer.plugin.clear === 'function') {
+        await viewer.plugin.clear();
+      } else if (typeof viewer.clear === 'function') {
+        await viewer.clear();
+      }
       document.getElementById('status').textContent = 'Viewer cleared';
     });
     document.querySelectorAll('[data-example]').forEach(a =>

--- a/test_app.py
+++ b/test_app.py
@@ -1,5 +1,5 @@
 import pytest
-from app import app, is_uniprot_id, build_afdb_pdb_url
+from app import app, is_uniprot_id, build_afdb_pdb_url, is_amino_acid_sequence
 
 
 def test_health_endpoint():
@@ -12,6 +12,11 @@ def test_health_endpoint():
 def test_is_uniprot_id():
     assert is_uniprot_id('P05067')
     assert not is_uniprot_id('insulin')
+
+
+def test_is_amino_acid_sequence():
+    assert is_amino_acid_sequence('ACDEFGHIKL')
+    assert not is_amino_acid_sequence('P05067')
 
 
 def test_search_by_uniprot(monkeypatch):
@@ -48,6 +53,13 @@ def test_search_by_name(monkeypatch):
         'accession': 'P01308',
         'pdb_url': build_afdb_pdb_url('P01308')
     }
+
+
+def test_sequence_search_returns_400():
+    client = app.test_client()
+    res = client.post('/search', json={'query': 'ACDEFGHIKL'})
+    assert res.status_code == 400
+    assert 'sequence' in res.get_json()['error'].lower()
 
 
 def test_proxy_requires_url():


### PR DESCRIPTION
## Summary
- handle network failures and sequence inputs in search endpoint
- support deployment under sub-paths and allow clearing via plugin API
- add tests for sequence rejection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49997b2d88328988e5af70de30f14